### PR TITLE
Fix hex color conversion and update tests

### DIFF
--- a/__test__/component/Component.test.tsx
+++ b/__test__/component/Component.test.tsx
@@ -1,18 +1,25 @@
-import { render, screen } from '@testing-library/react';
-import Button from '@/app/components/elements/static/Button';
-import adduserIcon from '../public/adduser.svg';
+import { fireEvent, render, screen } from '@testing-library/react'
+import Button from '@/components/elements/static/Button'
 
-test('render button tests', () => {
-    render(<Button
-            title={'My button'}
-         />);
-    const getTitle = screen.getByText('My button');
-    expect(getTitle).toBeInTheDocument();
-})
-test('find alt text of button tests', () => {
-    render(<Button
-            icon={adduserIcon}
-         />);
-    const altText = screen.getByAltText('icon')
-    expect(altText).toBeInTheDocument();
+describe('Button component', () => {
+  it('renders provided title', () => {
+    render(<Button icon="/icon.svg" title="My button" />)
+
+    expect(screen.getByText('My button')).toBeInTheDocument()
+  })
+
+  it('displays icon alt text when icon prop is provided', () => {
+    render(<Button icon="/icon.svg" />)
+
+    expect(screen.getByAltText('icon')).toBeInTheDocument()
+  })
+
+  it('calls the provided click handler when clicked', () => {
+    const handleClick = jest.fn()
+    render(<Button icon="/icon.svg" title="Clickable" handleClick={handleClick} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Clickable/ }))
+
+    expect(handleClick).toHaveBeenCalledTimes(1)
+  })
 })

--- a/__test__/functions/componentFunctions.test.ts
+++ b/__test__/functions/componentFunctions.test.ts
@@ -1,0 +1,15 @@
+import { hexToRGB } from '@/functions/componentFunctions'
+
+describe('hexToRGB', () => {
+  it('converts a six digit hex code to RGB', () => {
+    expect(hexToRGB('#2F80ED')).toEqual({ r: 47, g: 128, b: 237 })
+  })
+
+  it('converts a shorthand hex code to RGB', () => {
+    expect(hexToRGB('#0F0')).toEqual({ r: 0, g: 255, b: 0 })
+  })
+
+  it('throws an error for invalid values', () => {
+    expect(() => hexToRGB('invalid')).toThrow('Invalid hex color format')
+  })
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,18 +1,22 @@
 const nextJest = require('next/jest')
- 
+
 const createJestConfig = nextJest({
   // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
   dir: './',
 })
- 
+
 // Add any custom config to be passed to Jest
 /** @type {import('jest').Config} */
 const config = {
   // Add more setup options before each test is run
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testEnvironment: 'jest-environment-jsdom',
-  preset : 'ts-jest'
+  preset: 'ts-jest',
+  moduleNameMapper: {
+    '^@/public/(.*)$': '<rootDir>/public/$1',
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
 }
- 
+
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
 module.exports = createJestConfig(config)

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,9 @@
 import '@testing-library/jest-dom/extend-expect'
+import React from 'react'
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: React.forwardRef((props, ref) =>
+    React.createElement('img', { ...props, ref }),
+  ),
+}))

--- a/src/functions/componentFunctions.ts
+++ b/src/functions/componentFunctions.ts
@@ -2,23 +2,42 @@
 // ตัวอย่าง
 // input : #000000
 // return : rgb(0,0,0)
-export const hexToRGB: Function = (hex: string) => {
-    let r: number;
-    let g: number;
-    let b: number;
-    // ถ้าหากมีการใส่รูปย่อเช่น #000 จะให้ใช้สีเดียวกันตลอดทาง
-    if (hex.length === 4) {
-        r = parseInt(hex.slice(1, 3), 16);
-        g = parseInt(hex.slice(1, 3), 16);
-        b = parseInt(hex.slice(1, 3), 16);
-    } else { 
-        // ทำการ String slice แบ่งเป็น 2 ตัว 3 ชุด
-        // ตัวอย่าง #2F80ED จะได้ r = 2F g = 80 b = ED พวกนี้คือเลขฐาน 16
-        // นำเหล่านี้มาแปลงเป็นเลขฐาน 10 แล้วเก็บใส่ตัวแปร
-        r = parseInt(hex.slice(1, 3), 16);
-        g = parseInt(hex.slice(3, 5), 16);
-        b = parseInt(hex.slice(5, 7), 16);
-    }
-    //จากนั้น Return ค่าออกไปเป็น object
-    return { r: r, g: g, b: b };
+
+type RGBColor = {
+  r: number;
+  g: number;
+  b: number;
+};
+
+export const hexToRGB = (hex: string): RGBColor => {
+  if (typeof hex !== "string") {
+    throw new Error("Invalid hex color format");
+  }
+
+  const normalizedHex = hex.trim();
+  const shorthandRegex = /^#([0-9a-fA-F]{3})$/;
+  const fullRegex = /^#([0-9a-fA-F]{6})$/;
+
+  if (!shorthandRegex.test(normalizedHex) && !fullRegex.test(normalizedHex)) {
+    throw new Error("Invalid hex color format");
+  }
+
+  const expandShorthand = (value: string): string => value + value;
+
+  const [rHex, gHex, bHex] = normalizedHex.length === 4
+    ? normalizedHex
+        .slice(1)
+        .split("")
+        .map((char) => expandShorthand(char))
+    : [
+        normalizedHex.slice(1, 3),
+        normalizedHex.slice(3, 5),
+        normalizedHex.slice(5, 7),
+      ];
+
+  return {
+    r: parseInt(rHex, 16),
+    g: parseInt(gHex, 16),
+    b: parseInt(bHex, 16),
+  };
 };


### PR DESCRIPTION
## Summary
- fix `hexToRGB` to validate input and correctly handle shorthand hex values
- configure Jest with Next.js path aliases and mock `next/image` for tests
- rewrite the Button test suite and add coverage for `hexToRGB`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3581075948328b429c1b1eac28cb1