### PR TITLE
fix(e2e): use relative import paths in fixtures (tsconfig excludes e2e/)

### DIFF
--- a/e2e/fixtures/seed-data.fixture.ts
+++ b/e2e/fixtures/seed-data.fixture.ts
@@ -8,7 +8,7 @@
  *   import { testSemester, testTeacher, testSubject } from './fixtures/seed-data.fixture';
  */
 
-import { semester, day_of_week } from "@/prisma/generated/client";
+import { semester, day_of_week } from "../../prisma/generated/client";
 
 /**
  * Test Semester Data


### PR DESCRIPTION
## Fix E2E Test Import Paths

Fixes module resolution error where E2E tests cannot use `@/*` path aliases.

### Problem
- `tsconfig.json` explicitly excludes `e2e/**/*` directories
- Path aliases like `@/prisma/generated` are unavailable in excluded directories
- E2E tests were failing with `Cannot find module '@/prisma/generated/client'`

### Solution
Changed import in `e2e/fixtures/seed-data.fixture.ts`:
```diff
- import { semester, day_of_week } from "@/prisma/generated/client";
+ import { semester, day_of_week } from "../../prisma/generated/client";
```

### Changes
- **1 file changed:** `e2e/fixtures/seed-data.fixture.ts`
- **1 line modified:** Import statement (line 11)

### Related Issues
- Supersedes PR #47 (which had merge conflicts from generated Prisma files)
- Fixes E2E test failures due to import resolution

### Testing
- ✅ Import path resolves correctly with relative path
- ✅ No other E2E files use invalid `@/` aliases
- ✅ Clean commit without generated files

### Notes
This is a **minimal, surgical fix** extracted from PR #47. Unlike PR #47, this PR:
- Contains only manual code changes (no generated files)
- Has no merge conflicts
- Can be safely merged to main

Once merged, PR #47 should be closed as obsolete.