### PR TITLE
e2e(prod): scheduling smoke + opt-in CRUD suite

### DIFF
--- a/.github/workflows/prod-crud-smoke.yml
+++ b/.github/workflows/prod-crud-smoke.yml
@@ -1,0 +1,69 @@
+name: Prod CRUD Smoke (Deployed)
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Deployed base URL (overrides vars.E2E_BASE_URL)"
+        required: false
+        type: string
+      semester_id:
+        description: "Semester ID like 1-2568 (overrides vars.E2E_SEMESTER_ID)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: prod-crud-smoke-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  prod-crud-smoke:
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    env:
+      CI: "true"
+      E2E_ALLOW_MUTATIONS: "true"
+      # Required for `prisma generate` during pnpm postinstall (prisma.config.ts uses env("DATABASE_URL")).
+      DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
+      E2E_BASE_URL: ${{ github.event.inputs.base_url || vars.E2E_BASE_URL || 'https://phrasongsa-timetable.vercel.app' }}
+      E2E_SEMESTER_ID: ${{ github.event.inputs.semester_id || vars.E2E_SEMESTER_ID || '1-2568' }}
+      E2E_ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL }}
+      E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install chromium
+
+      - name: Run prod CRUD smoke
+        run: pnpm test:prod:crud
+
+      - name: Upload report and artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: prod-crud-smoke-${{ github.run_id }}
+          retention-days: 7
+          path: |
+            playwright-report-prod/**
+            test-results/prod-artifacts/**
+            test-results/prod-results.*
+

--- a/docs/testing/RUN_PROD_VISUAL_SMOKE.md
+++ b/docs/testing/RUN_PROD_VISUAL_SMOKE.md
@@ -13,6 +13,7 @@ Optional:
 
 - `E2E_START_WEBSERVER=true` to run `pnpm dev` locally (only when `E2E_BASE_URL` points to `http://localhost:3000`)
 - `PLAYWRIGHT_PROD_AUTH_FILE` to override the storageState location (default `playwright/.auth/prod-admin.json`)
+- `E2E_ALLOW_MUTATIONS=true` to enable CRUD smoke tests that create/update/delete `E2E-*` tagged records
 
 ## Commands
 
@@ -38,6 +39,19 @@ Open the HTML report:
 
 ```bash
 pnpm test:prod:visual:report
+```
+
+Run scheduling (read-only) smoke checks (no screenshot baselines required):
+
+```bash
+pnpm test:prod:scheduling
+```
+
+Run mutating CRUD smoke (requires opt-in):
+
+```bash
+# Set E2E_ALLOW_MUTATIONS=true in your environment, then:
+pnpm test:prod:crud
 ```
 
 ## Baselines (Screenshots + ARIA)
@@ -87,3 +101,8 @@ Configure:
 - Repository variables (recommended):
   - `E2E_BASE_URL`
   - `E2E_SEMESTER_ID`
+
+Mutating CRUD workflow (manual-only): `.github/workflows/prod-crud-smoke.yml`
+
+- Uses the same secrets/vars as above
+- Forces `E2E_ALLOW_MUTATIONS=true` for the run

--- a/e2e/prod/crud/admin-crud.smoke.spec.ts
+++ b/e2e/prod/crud/admin-crud.smoke.spec.ts
@@ -1,0 +1,267 @@
+import { expect, test, type Page } from "@playwright/test";
+import { expectAdminSession } from "../helpers/session";
+import { goToRooms, goToSubjects, goToTeachers } from "../helpers/navigation";
+
+test.describe.configure({ mode: "serial", timeout: 120_000 });
+
+test.skip(
+  process.env.E2E_ALLOW_MUTATIONS !== "true",
+  "Set E2E_ALLOW_MUTATIONS=true to enable production CRUD smoke tests.",
+);
+
+const successToast = (page: Page) =>
+  page
+    .locator(
+      [
+        ".notistack-SnackbarContainer [role='alert']",
+        ".notistack-SnackbarContainer .MuiAlert-root",
+        ".notistack-SnackbarContainer .notistack-MuiContent",
+        ".MuiSnackbar-root [role='alert']",
+      ].join(","),
+    )
+    .first();
+
+async function confirmDialogIfPresent(page: Page) {
+  const dialog = page.getByRole("dialog").first();
+  if (!(await dialog.isVisible({ timeout: 1500 }).catch(() => false))) return;
+
+  const preferredConfirm = dialog
+    .locator(
+      [
+        "button[type='submit']",
+        "button:has([data-testid*='confirm' i])",
+        "button:has([data-testid*='delete' i])",
+        "button[aria-label*='delete' i]",
+        "button[class*='MuiButton-containedError']",
+        "button[class*='MuiButton-colorError']",
+        "button:has-text('Delete')",
+        "button:has-text('Confirm')",
+        "button:has-text('Yes')",
+        "button:has-text('ตกลง')",
+        "button:has-text('ยืนยัน')",
+        "button:has-text('ลบ')",
+      ].join(","),
+    )
+    .first();
+
+  if (await preferredConfirm.isVisible({ timeout: 1500 }).catch(() => false)) {
+    await preferredConfirm.click();
+    return;
+  }
+
+  const fallback = dialog.getByRole("button").last();
+  if (await fallback.isVisible({ timeout: 1500 }).catch(() => false)) {
+    await fallback.click();
+  }
+}
+
+async function selectRowByText(page: Page, text: string) {
+  const row = page.locator("tbody tr").filter({ hasText: text }).first();
+  await expect(row).toBeVisible({ timeout: 20_000 });
+  const checkbox = row.locator('input[type="checkbox"]').first();
+  if (await checkbox.isVisible({ timeout: 2000 }).catch(() => false)) {
+    await checkbox.check();
+  } else {
+    await row.click();
+  }
+}
+
+test.describe("CRUD (mutating) – Teachers", () => {
+  test("create → edit → delete teacher", async ({ page }, testInfo) => {
+    await expectAdminSession(page);
+    await goToTeachers(page);
+
+    const id = `${Date.now()}-${testInfo.retry}`;
+    const firstName = `E2E-Teacher-${id}`;
+    const lastName = `E2E-${id}`;
+    const email = `e2e_teacher_${id}@test.local`;
+    let currentFirstName = firstName;
+
+    // Create
+    await page.getByTestId("add-teacher-button").click();
+    await page.getByTestId("firstname-0").fill(firstName);
+    await page.getByTestId("lastname-0").fill(lastName);
+    const emailInput = page.getByTestId("email-0");
+    if (await emailInput.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await emailInput.fill(email);
+    }
+    await page.getByTestId("add-teacher-submit").click();
+    await expect(successToast(page)).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByText(firstName).first()).toBeVisible({
+      timeout: 20_000,
+    });
+
+    // Edit (inline)
+    const search = page.getByTestId("teacher-search");
+    if (await search.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await search.fill(firstName);
+      await page.waitForTimeout(300);
+    }
+    await selectRowByText(page, firstName);
+    const editButton = page.locator('button[aria-label="edit"]').first();
+    if (await editButton.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await editButton.click();
+      const rowInput = page
+        .locator("tbody tr input:not([type='checkbox']):visible")
+        .first();
+      if (await rowInput.isVisible({ timeout: 5000 }).catch(() => false)) {
+        currentFirstName = `${firstName}-Edited`;
+        await rowInput.fill(currentFirstName);
+      }
+      await page.locator('button[aria-label="save"]').first().click();
+      await expect(successToast(page)).toBeVisible({ timeout: 20_000 });
+    }
+
+    // Delete
+    if (await search.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await search.fill(currentFirstName);
+      await page.waitForTimeout(300);
+    }
+    await selectRowByText(page, currentFirstName);
+    await page.locator('button[aria-label="delete"]').first().click();
+    await confirmDialogIfPresent(page);
+    await expect(page.getByText(currentFirstName).first()).not.toBeVisible({
+      timeout: 20_000,
+    });
+  });
+});
+
+test.describe("CRUD (mutating) – Subjects", () => {
+  test("create → edit → delete subject", async ({ page }, testInfo) => {
+    await expectAdminSession(page);
+    await goToSubjects(page);
+
+    const id = `${Date.now()}-${testInfo.retry}`;
+    const subjectCode = `E2E${(Date.now() % 100000).toString().padStart(5, "0")}`;
+    const subjectName = `E2E Subject ${id}`;
+
+    // Create (inline)
+    const addButton = page
+      .getByRole("button", { name: /เพิ่ม|add/i })
+      .first();
+    await expect(addButton).toBeVisible({ timeout: 20_000 });
+    await addButton.click();
+
+    const editingRow = page
+      .locator("tbody tr")
+      .filter({ has: page.locator('input[type="text"]') })
+      .first();
+    await expect(editingRow).toBeVisible({ timeout: 20_000 });
+
+    const textInputs = editingRow.locator('input[type="text"]');
+    await textInputs.first().fill(subjectCode);
+    if ((await textInputs.count()) > 1) {
+      await textInputs.nth(1).fill(subjectName);
+    }
+
+    // Some environments require LearningArea when Category defaults to CORE.
+    const comboboxes = editingRow.locator('[role="combobox"]');
+    const comboboxCount = await comboboxes.count();
+    if (comboboxCount > 0) {
+      const learningAreaSelect = comboboxes.nth(Math.max(0, comboboxCount - 1));
+      if (await learningAreaSelect.isVisible({ timeout: 2000 }).catch(() => false)) {
+        await learningAreaSelect.click();
+        const firstOption = page.getByRole("option").first();
+        if (await firstOption.isVisible({ timeout: 2000 }).catch(() => false)) {
+          await firstOption.click();
+        }
+      }
+    }
+
+    await page.locator('button[aria-label="save"]').first().click();
+    await expect(successToast(page)).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByText(subjectCode).first()).toBeVisible({
+      timeout: 20_000,
+    });
+
+    // Edit
+    await selectRowByText(page, subjectCode);
+    const editButton = page.locator('button[aria-label="edit"]').first();
+    if (await editButton.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await editButton.click();
+      const editRow = page
+        .locator("tbody tr")
+        .filter({ hasText: subjectCode })
+        .first();
+      const inputs = editRow.locator('input[type="text"]:visible');
+      if ((await inputs.count()) > 1) {
+        await inputs.nth(1).fill(`${subjectName} (Edited)`);
+      }
+      await page.locator('button[aria-label="save"]').first().click();
+      await expect(successToast(page)).toBeVisible({ timeout: 20_000 });
+    }
+
+    // Delete
+    await selectRowByText(page, subjectCode);
+    await page.locator('button[aria-label="delete"]').first().click();
+    await confirmDialogIfPresent(page);
+    await expect(page.getByText(subjectCode).first()).not.toBeVisible({
+      timeout: 20_000,
+    });
+  });
+});
+
+test.describe("CRUD (mutating) – Rooms", () => {
+  test("create → edit → delete room", async ({ page }, testInfo) => {
+    await expectAdminSession(page);
+    await goToRooms(page);
+
+    const id = `${Date.now()}-${testInfo.retry}`;
+    const roomName = `E2E${(Date.now() % 100000).toString().padStart(5, "0")}`;
+    const building = `E2E-Building-${(Date.now() % 1000).toString().padStart(3, "0")}`;
+    const floor = "1";
+
+    // Create (inline)
+    const addButton = page
+      .getByRole("button", { name: /เพิ่ม|add/i })
+      .first();
+    await expect(addButton).toBeVisible({ timeout: 20_000 });
+    await addButton.click();
+
+    const editingRow = page
+      .locator("tbody tr")
+      .filter({ has: page.locator('input[type="text"]') })
+      .first();
+    await expect(editingRow).toBeVisible({ timeout: 20_000 });
+
+    const textInputs = editingRow.locator('input[type="text"]');
+    await textInputs.first().fill(roomName);
+    if ((await textInputs.count()) > 1) {
+      await textInputs.nth(1).fill(building);
+    }
+    if ((await textInputs.count()) > 2) {
+      await textInputs.nth(2).fill(floor);
+    }
+
+    await page.locator('button[aria-label="save"]').first().click();
+    await expect(successToast(page)).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByText(roomName).first()).toBeVisible({
+      timeout: 20_000,
+    });
+
+    // Edit (optional; depends on EditableTable columns)
+    await selectRowByText(page, roomName);
+    const editButton = page.locator('button[aria-label="edit"]').first();
+    if (await editButton.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await editButton.click();
+      const editRow = page
+        .locator("tbody tr")
+        .filter({ hasText: roomName })
+        .first();
+      const inputs = editRow.locator('input[type="text"]:visible');
+      if ((await inputs.count()) > 1) {
+        await inputs.nth(1).fill(`${building}-Edited`);
+      }
+      await page.locator('button[aria-label="save"]').first().click();
+      await expect(successToast(page)).toBeVisible({ timeout: 20_000 });
+    }
+
+    // Delete
+    await selectRowByText(page, roomName);
+    await page.locator('button[aria-label="delete"]').first().click();
+    await confirmDialogIfPresent(page);
+    await expect(page.getByText(roomName).first()).not.toBeVisible({
+      timeout: 20_000,
+    });
+  });
+});

--- a/e2e/prod/helpers/navigation.ts
+++ b/e2e/prod/helpers/navigation.ts
@@ -45,6 +45,11 @@ export async function goToScheduleConfig(page: Page) {
   await gotoAndReady(page, `/schedule/${semester}/config`);
 }
 
+export async function goToScheduleAssign(page: Page) {
+  const semester = getSemesterId();
+  await gotoAndReady(page, `/schedule/${semester}/assign`);
+}
+
 export async function goToTeacherArrange(page: Page) {
   const semester = getSemesterId();
   await gotoAndReady(page, `/schedule/${semester}/arrange/teacher-arrange`);
@@ -53,6 +58,11 @@ export async function goToTeacherArrange(page: Page) {
 export async function goToLockOverview(page: Page) {
   const semester = getSemesterId();
   await gotoAndReady(page, `/schedule/${semester}/lock`);
+}
+
+export async function goToConflictDetector(page: Page) {
+  const semester = getSemesterId();
+  await gotoAndReady(page, `/dashboard/${semester}/conflicts`);
 }
 
 export async function goToExportEntry(page: Page) {

--- a/e2e/prod/helpers/session.ts
+++ b/e2e/prod/helpers/session.ts
@@ -1,0 +1,11 @@
+import { expect, type Page } from "@playwright/test";
+
+type SessionBody = { user?: { role?: string; email?: string } };
+
+export async function expectAdminSession(page: Page) {
+  const res = await page.request.get("/api/auth/get-session");
+  expect(res.ok()).toBeTruthy();
+  const body = (await res.json().catch(() => ({}))) as SessionBody;
+  expect(body.user?.role).toBe("admin");
+}
+

--- a/e2e/prod/scheduling/admin-scheduling.smoke.spec.ts
+++ b/e2e/prod/scheduling/admin-scheduling.smoke.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test, type Page } from "@playwright/test";
+import { expectAdminSession } from "../helpers/session";
+import {
+  goToConflictDetector,
+  goToScheduleAssign,
+  goToScheduleConfig,
+  goToTeacherArrange,
+} from "../helpers/navigation";
+import { mainRegion } from "../helpers/visual";
+
+test.describe.configure({ mode: "serial", timeout: 120_000 });
+
+async function expectHasInteractiveControls(pageName: string, page: Page) {
+  const semanticMain = page.locator("main, [role='main']").first();
+  if (await semanticMain.isVisible({ timeout: 2000 }).catch(() => false)) {
+    await expect(semanticMain).toMatchAriaSnapshot(`
+      - main:
+        - button
+    `);
+    return;
+  }
+
+  const snapshot = await mainRegion(page).ariaSnapshot();
+  expect(
+    snapshot.includes("button") || snapshot.includes("combobox"),
+    `Expected ${pageName} to contain interactive controls`,
+  ).toBe(true);
+}
+
+test("schedule assign page renders", async ({ page }) => {
+  await expectAdminSession(page);
+  await goToScheduleAssign(page);
+
+  // The page should have some assignment controls; tolerate varying layouts.
+  await expect(mainRegion(page)).toBeVisible({ timeout: 20_000 });
+  await expectHasInteractiveControls("schedule assign", page);
+});
+
+test("conflict detector dashboard renders", async ({ page }) => {
+  await expectAdminSession(page);
+  await goToConflictDetector(page);
+
+  await expect(mainRegion(page)).toBeVisible({ timeout: 20_000 });
+  await expectHasInteractiveControls("conflicts dashboard", page);
+});
+
+test("config page shows publish/status badge", async ({ page }) => {
+  await expectAdminSession(page);
+  await goToScheduleConfig(page);
+
+  const statusBadge = page.getByTestId("config-status-badge");
+  await expect(statusBadge).toBeVisible({ timeout: 20_000 });
+
+  const snapshot = await mainRegion(page).ariaSnapshot();
+  expect(
+    snapshot.includes("button") || snapshot.includes("combobox"),
+    "Expected config page to contain interactive controls",
+  ).toBe(true);
+});
+
+test("teacher arrange surface shows grid or conflict UI", async ({ page }) => {
+  await expectAdminSession(page);
+  await goToTeacherArrange(page);
+
+  const grid = page.locator("[data-testid='timeslot-grid']").first();
+  const markers = page.locator(
+    '[data-testid="conflict"], [class*="conflict"], [class*="error"], [class*="warning"], svg[color="error"]',
+  );
+
+  const hasGrid = await grid.isVisible({ timeout: 15_000 }).catch(() => false);
+  const hasMarkers = (await markers.count().catch(() => 0)) > 0;
+
+  expect.soft(
+    hasGrid || hasMarkers,
+    "Expected a timeslot grid or conflict markers to be present",
+  ).toBe(true);
+
+  await expect(mainRegion(page)).toBeVisible({ timeout: 20_000 });
+});

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "test:prod:visual": "playwright test --config=playwright.config.prod.ts",
     "test:prod:visual:ui": "playwright test --config=playwright.config.prod.ts --ui",
     "test:prod:visual:update": "playwright test --config=playwright.config.prod.ts --update-snapshots",
+    "test:prod:scheduling": "playwright test --config=playwright.config.prod.ts e2e/prod/scheduling",
+    "test:prod:crud": "playwright test --config=playwright.config.prod.ts --project=prod-desktop-admin-crud",
     "test:prod:visual:report": "playwright show-report playwright-report-prod",
     "test:report": "playwright show-report",
     "test:e2e:ci-mode": "pnpm build && CI=true pnpm test:e2e:manual",

--- a/playwright.config.prod.ts
+++ b/playwright.config.prod.ts
@@ -37,6 +37,8 @@ const shouldStartWebServer =
     }
   })();
 
+const allowMutations = process.env.E2E_ALLOW_MUTATIONS === "true";
+
 export default defineConfig({
   testDir: "./e2e/prod",
   testMatch: ["**/*.spec.ts", "**/*.setup.ts"],
@@ -93,9 +95,23 @@ export default defineConfig({
         viewport: { width: 1440, height: 900 },
         storageState: "playwright/.auth/prod-admin.json",
       },
-      testMatch: ["**/visual/**/*.spec.ts"],
+      testMatch: ["**/visual/**/*.spec.ts", "**/smoke/**/*.spec.ts", "**/scheduling/**/*.spec.ts"],
       dependencies: ["prod-setup"],
     },
+    ...(allowMutations
+      ? [
+          {
+            name: "prod-desktop-admin-crud",
+            use: {
+              ...devices["Desktop Chrome"],
+              viewport: { width: 1440, height: 900 },
+              storageState: "playwright/.auth/prod-admin.json",
+            },
+            testMatch: ["**/crud/**/*.spec.ts"],
+            dependencies: ["prod-setup"],
+          },
+        ]
+      : []),
   ],
 
   webServer: shouldStartWebServer


### PR DESCRIPTION
Adds read-only scheduling smoke checks to the prod suite and introduces an opt-in CRUD smoke project/workflow gated by E2E_ALLOW_MUTATIONS.\n\n- New: e2e/prod/scheduling admin-scheduling.smoke.spec.ts\n- New: e2e/prod/crud admin-crud.smoke.spec.ts (mutating; E2E-* tagged; cleans up)\n- New: .github/workflows/prod-crud-smoke.yml (workflow_dispatch only)\n- Update: playwright.config.prod.ts conditional CRUD project\n- Docs: docs/testing/RUN_PROD_VISUAL_SMOKE.md\n