### PR TITLE
Stabilize prod subject CRUD smoke

### DIFF
--- a/e2e/prod/crud/admin-crud.smoke.spec.ts
+++ b/e2e/prod/crud/admin-crud.smoke.spec.ts
@@ -257,6 +257,7 @@ test.describe("CRUD (mutating) – Subjects", () => {
     await expect(createdRow).toBeVisible({ timeout: 60_000 });
 
     // Edit
+    await fillSearch(page, subjectCode);
     await selectRowByText(page, subjectCode);
     const editButton = page.locator('button[aria-label="edit"]').first();
     if (await editButton.isVisible({ timeout: 5000 }).catch(() => false)) {
@@ -275,6 +276,8 @@ test.describe("CRUD (mutating) – Subjects", () => {
     }
 
     // Delete
+    await goToSubjects(page);
+    await fillSearch(page, subjectCode);
     await selectRowByText(page, subjectCode);
     await page.locator('button[aria-label="delete"]').first().click();
     await confirmDialogIfPresent(page);


### PR DESCRIPTION
After subject creation fix, the prod CRUD smoke could fail at delete if the created row falls off the first page after edit. Re-navigate to Subjects and re-apply search before delete.