### PR TITLE
Stabilize room delete check in prod CRUD smoke

### DIFF
--- a/e2e/prod/crud/admin-crud.smoke.spec.ts
+++ b/e2e/prod/crud/admin-crud.smoke.spec.ts
@@ -349,8 +349,10 @@ test.describe("CRUD (mutating) – Rooms", () => {
     await selectRowByText(page, roomName);
     await page.locator('button[aria-label="delete"]').first().click();
     await confirmDialogIfPresent(page);
+    await goToRooms(page);
+    await fillSearch(page, roomName);
     await expect(page.getByText(roomName).first()).not.toBeVisible({
-      timeout: 20_000,
+      timeout: 60_000,
     });
   });
 });


### PR DESCRIPTION
After fixing room creation, prod CRUD smoke could still fail at delete because UI refresh is async. Reload Rooms and re-filter by name to confirm backend deletion.