### PR TITLE
Fix room delete action wiring

### DIFF
--- a/src/app/management/rooms/component/RoomsTable.tsx
+++ b/src/app/management/rooms/component/RoomsTable.tsx
@@ -103,7 +103,7 @@ const handleUpdate = async (rooms: Partial<room>[]) => {
 
 // Wrapper for delete action
 const handleDelete = async (ids: (string | number)[]) => {
-  return await deleteRoomsAction({ roomIds: ids as number[] });
+  return await deleteRoomsAction(ids as number[]);
 };
 
 export default function RoomsTable({ tableData, mutate }: RoomsTableProps) {


### PR DESCRIPTION
Rooms delete was wired with the wrong input shape (object) while deleteRoomsAction expects number[]. This prevented deletion in /management/rooms and caused prod CRUD smoke to fail.