### PR TITLE
Fix grade level delete action wiring

### DIFF
--- a/src/app/management/gradelevel/component/GradeLevelTable.tsx
+++ b/src/app/management/gradelevel/component/GradeLevelTable.tsx
@@ -182,7 +182,7 @@ const handleUpdate = async (grades: Partial<gradelevel>[]) => {
 
 // Wrapper for delete action
 const handleDelete = async (ids: (string | number)[]) => {
-  return await deleteGradeLevelsAction({ gradeIds: ids as string[] });
+  return await deleteGradeLevelsAction(ids as string[]);
 };
 
 export default function GradeLevelTable({


### PR DESCRIPTION
deleteGradeLevelsAction expects an array of GradeIDs, but the UI passed { gradeIds: ids }, so deletions were no-op and could break CRUD/E2E. Pass the ID array directly.