### PR TITLE
test(smoke): fix stale config label selector vs ConfigSummaryClient (17x)

### DIFF
--- a/e2e/smoke/critical-smoke.spec.ts
+++ b/e2e/smoke/critical-smoke.spec.ts
@@ -352,10 +352,11 @@ test.describe("Critical Path Smoke Tests", () => {
       await page.goto(`/schedule/${TEST_SEMESTER}/config`);
       await page.waitForLoadState("networkidle");
 
-      // Look for config labels that show current values (Thai text)
-      // "กำหนดเวลาเริ่มคาบแรก" (Set first period start time), "กำหนดคาบพักเที่ยง" (Set lunch break)
+      // Look for config summary labels that show current values (Thai text).
+      // ConfigSummaryClient renders: "คาบเรียนต่อวัน" (periods per day),
+      // "ความยาวคาบ" (period duration), "เวลาเริ่ม" (start time), "วันเรียน" (school days).
       const configLabels = page.locator(
-        "text=/กำหนดเวลาเริ่มคาบแรก|กำหนดคาบพักเที่ยง|กำหนดวันในตารางสอน/i",
+        "text=/คาบเรียนต่อวัน|ความยาวคาบ|เวลาเริ่ม|วันเรียน/i",
       );
       await expect(configLabels.first()).toBeVisible({ timeout: 15000 });
 


### PR DESCRIPTION
## What

The smoke test `Config form displays current settings` (in `e2e/smoke/critical-smoke.spec.ts`, section "3. Schedule Configuration") had a **stale label selector**.

The config route `src/app/schedule/[academicYear]/[semester]/config/page.tsx` now renders the read-only `ConfigSummaryClient` summary component instead of the old config form. The old form exposed Thai labels like `กำหนดเวลาเริ่มคาบแรก` / `กำหนดคาบพักเที่ยง` / `กำหนดวันในตารางสอน`, which the summary no longer renders — so the `configLabels` assertion never matched and the test failed before reaching the value check.

## Fix (spec file only)

Repointed the label selector at the labels `ConfigSummaryClient` actually renders:

- before: `text=/กำหนดเวลาเริ่มคาบแรก|กำหนดคาบพักเที่ยง|กำหนดวันในตารางสอน/i`
- after: `text=/คาบเรียนต่อวัน|ความยาวคาบ|เวลาเริ่ม|วันเรียน/i`

The numeric value assertion (`text=/\d+.*คาบ|\d+.*นาที/`) is **unchanged** — it still matches the summary's `{TimeslotPerDay} คาบ` and `{Duration} นาที/คาบ` cells. The test's intent (config page shows the saved settings: a label + a numeric value) is preserved.

No production code changed.

## Notes

- Sibling section-3 tests reference the same retired labels (`กำหนดคาบต่อวัน` / `กำหนดระยะเวลาต่อคาบ`) and share this staleness; they are out of scope for 17x and not touched here.
- The summary table (labels + values) only renders when the semester config is seeded and parseable — the original test already assumed this.
- CI E2E may show chronic red (8kp), unrelated to this spec-only fix.

## Verification

- `pnpm typecheck` → clean (no errors).
- Verified against `ConfigSummaryClient.tsx` that all four asserted labels render in its JSX (lines 173/178/182/186). E2E not run locally (shared docker postgres + fixed ports collide with sibling agents).