### PR TITLE
fix(schedule): RSC crash in arrange empty-state (8kp)

### DIFF
--- a/src/app/schedule/[academicYear]/[semester]/arrange/layout.tsx
+++ b/src/app/schedule/[academicYear]/[semester]/arrange/layout.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import Link from "next/link";
 import { Container, Box, Grid, Paper, Stack, Typography, Button } from "@mui/material";
 import AssignmentIndIcon from "@mui/icons-material/AssignmentInd";
 import { prisma } from "@/lib/prisma";
@@ -63,7 +62,6 @@ export default async function ArrangeLayout({
               เพื่อให้ระบบรู้ว่ามีรายวิชาใดต้องวางลงในตาราง
             </Typography>
             <Button
-              component={Link}
               href={`/schedule/${yearStr}/${semStr}/assign`}
               variant="contained"
               size="large"


### PR DESCRIPTION
## Root cause (8kp investigation)
The e2e suite's WebServer log contained a server-side runtime crash:
`Error: Functions cannot be passed directly to Client Components ...`

Traced to `src/app/schedule/[academicYear]/[semester]/arrange/layout.tsx` — a **Server Component** that, in its zero-responsibility empty state, rendered `<Button component={Link}>`. Passing the `Link` component reference as a prop to MUI Button (a Client Component) can't be serialized across the RSC boundary → 500. `arrange/layout.tsx` is the only server-component `component={Link}` in the codebase (the other three are in `*Client.tsx` client components).

This 500s the arrange page whenever a term has config + timeslots but no teaching assignments yet (the mid-wizard state e2e exercises). `pnpm build` does **not** catch it — only runtime/e2e does.

## Fix
Drop `component={Link}`; MUI `Button` with `href` renders a plain `<a>`, so no function crosses the RSC boundary. Navigation behavior unchanged.

## Verification
- `pnpm typecheck`: clean.
- Browser (signed-in): normal arrange path (`/schedule/2568/1/arrange`) renders; adjacent config-redirect path renders — **0 console errors, no RSC error**. (The exact empty-state needs a synthetic config+timeslots+0-assignments term; source is uniquely identified + fix is the canonical pattern.)

## Scope note
This fixes one **real server bug** the e2e exposed. It does **not** green the whole 8kp suite — the dominant cause there is **selector drift** (~40 specs using stale selectors from the wizard/config/redesign refactors) plus stale visual snapshots, which 8kp's own design notes recommend addressing incrementally as the redesign settles.

Beads: `school-timetable-senior-project-8kp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)