### PR TITLE
fix(schedule): 400 not 500 on non-numeric teacher id (8kp)

### DIFF
--- a/src/app/api/schedule/teacher/[id]/route.ts
+++ b/src/app/api/schedule/teacher/[id]/route.ts
@@ -49,6 +49,12 @@ export async function GET(
 
     const { id } = await params;
     const teacherId = parseInt(id);
+    if (Number.isNaN(teacherId)) {
+      return NextResponse.json(
+        { success: false, error: { message: "Invalid teacher id" } },
+        { status: 400 },
+      );
+    }
     const searchParams = request.nextUrl.searchParams;
     const year = searchParams.get("year");
     const semesterNum = searchParams.get("semester");

--- a/src/app/schedule/[academicYear]/[semester]/arrange/@grid/page.tsx
+++ b/src/app/schedule/[academicYear]/[semester]/arrange/@grid/page.tsx
@@ -156,7 +156,7 @@ export default function GridSlot() {
     isLoading: scheduleLoading,
     mutate,
   } = useSWR(
-    teacher
+    teacher && /^\d+$/.test(teacher)
       ? `/api/schedule/teacher/${teacher}?year=${academicYear}&semester=${semester}`
       : null,
     (url) => fetch(url).then((r) => r.json()),


### PR DESCRIPTION
## Root cause (8kp investigation)
The e2e WebServer log repeatedly showed:
`GET /api/schedule/teacher/[id] failed` → `Invalid prisma.class_schedule.findMany() invocation … Argument TeacherID is missing`.

`route.ts` did `const teacherId = parseInt(id)` and validated `year`/`semester` but **not** the id. The arrange `@grid` page builds the URL from `searchParams.get("teacher")`; a non-numeric value (e.g. a stale/`undefined` `?teacher=` param) yields `parseInt` → `NaN` → `TeacherID: NaN`, which Prisma treats as missing → unhandled 500 + error-log spam.

## Fix (defense-in-depth)
- **Route**: return `400` on `Number.isNaN(teacherId)` instead of letting Prisma 500.
- **Caller** (`arrange/@grid/page.tsx`): gate the SWR fetch on a numeric `teacher` (`/^\d+$/`) so a bad `?teacher` param never fires the request.

## Verification
- `pnpm typecheck`: clean.
- An API must not 500 on a malformed path param; this returns a proper 400 and the client's existing SWR `onError` snackbar handles it.

## Scope
Second real server bug from the 8kp investigation (after the RSC crash in #234). Does not address selector drift (the suite's dominant redness), per the agreed "real bugs only" scope.

Beads: `school-timetable-senior-project-8kp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)