### PR TITLE
fix(a11y): program year page title as semantic h1 (TC-PROG-050)

### DIFF
--- a/src/app/management/program/year/[year]/YearPageHeader.tsx
+++ b/src/app/management/program/year/[year]/YearPageHeader.tsx
@@ -165,6 +165,7 @@ export function YearPageHeader({ year, children }: YearPageHeaderProps) {
               <Stack direction="row" alignItems="center" spacing={1.5}>
                 <Typography
                   variant="h4"
+                  component="h1"
                   fontWeight={800}
                   sx={{
                     background: `linear-gradient(135deg, #1e293b 0%, #475569 100%)`,


### PR DESCRIPTION
The `/management/program/year/[year]` page title used `variant="h4"` (renders
`<h4>`), so the page had no `<h1>`/`<h2>` — failing the a11y heading-structure
e2e check (TC-PROG-050) and leaving no top-level heading landmark for screen
readers. Add `component="h1"` so it's a semantic `<h1>` while keeping the h4 style.

Bucket C (6o2). typecheck + lint green; CI E2E runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)