### PR TITLE
test(e2e): config smoke specs assert ConfigSummaryClient (not old form)

### DIFF
--- a/e2e/smoke/critical-smoke.spec.ts
+++ b/e2e/smoke/critical-smoke.spec.ts
@@ -326,26 +326,29 @@ test.describe("Critical Path Smoke Tests", () => {
       // Verify page loads successfully - wait for any fetch response
       await page.waitForLoadState("networkidle");
 
-      // Config page is a form with configuration options, not a table
-      // Wait for config form elements to render
-      const configContent = page
-        .locator("text=/กำหนดคาบต่อวัน/")
-        .or(page.locator('[class*="Skeleton"]'));
-      await expect(configContent.first()).toBeVisible({ timeout: 15000 });
+      // Config page is a read-only ConfigSummaryClient: status badge (config
+      // exists) or empty-state warning settles after the SWR spinner.
+      const statusBadge = page.getByTestId("config-status-badge");
+      const emptyState = page.getByText(
+        "ยังไม่มีการตั้งค่าตารางเรียนสำหรับภาคเรียนนี้",
+      );
+      await expect(statusBadge.or(emptyState)).toBeVisible({ timeout: 30000 });
     });
 
     test("Verify config form loads with options", async ({ page }) => {
       await page.goto(`/schedule/${TEST_SEMESTER}/config`);
       await page.waitForLoadState("networkidle");
 
-      // Wait for config form to load - check for config labels
-      // Thai: "กำหนดคาบต่อวัน" (Set periods per day), "กำหนดระยะเวลาต่อคาบ" (Set duration per period)
-      await expect(page.locator("text=/กำหนดคาบต่อวัน/")).toBeVisible({
-        timeout: 15000,
-      });
-      await expect(page.locator("text=/กำหนดระยะเวลาต่อคาบ/")).toBeVisible({
-        timeout: 15000,
-      });
+      // Read-only summary: when config exists it lists the saved parameters,
+      // otherwise the empty-state warning shows.
+      const statusBadge = page.getByTestId("config-status-badge");
+      const emptyState = page.getByText(
+        "ยังไม่มีการตั้งค่าตารางเรียนสำหรับภาคเรียนนี้",
+      );
+      await expect(statusBadge.or(emptyState)).toBeVisible({ timeout: 30000 });
+      if (await statusBadge.isVisible()) {
+        await expect(page.getByText("คาบเรียนต่อวัน")).toBeVisible();
+      }
     });
 
     test("Config form displays current settings", async ({ page }) => {
@@ -366,27 +369,28 @@ test.describe("Critical Path Smoke Tests", () => {
     });
 
     test("Navigation between semesters works", async ({ page }) => {
+      const configSettled = () =>
+        expect(
+          page
+            .getByTestId("config-status-badge")
+            .or(
+              page.getByText(
+                "ยังไม่มีการตั้งค่าตารางเรียนสำหรับภาคเรียนนี้",
+              ),
+            ),
+        ).toBeVisible({ timeout: 30000 });
+
       // Start at first semester
       await page.goto(`/schedule/2568/1/config`);
       await page.waitForLoadState("networkidle");
       await expect(page).toHaveURL(/\/schedule\/2568\/1\/config/);
-      await expect(page.locator("text=/กำหนดคาบต่อวัน/")).toBeVisible({
-        timeout: 15000,
-      });
+      await configSettled();
 
       // Navigate to second semester
       await page.goto(`/schedule/2568/2/config`);
       await page.waitForLoadState("networkidle");
       await expect(page).toHaveURL(/\/schedule\/2568\/2\/config/);
-      await expect(page.locator("text=/กำหนดคาบต่อวัน/")).toBeVisible({
-        timeout: 15000,
-      });
-
-      // Both should load successfully - verify config form rendered
-      const finalConfig = page
-        .locator("text=/กำหนดคาบต่อวัน/")
-        .or(page.locator('[class*="Skeleton"]'));
-      await expect(finalConfig.first()).toBeVisible({ timeout: 15000 });
+      await configSettled();
     });
   });
 

--- a/e2e/smoke/semester-smoke.spec.ts
+++ b/e2e/smoke/semester-smoke.spec.ts
@@ -35,13 +35,14 @@ test.describe("Semester Smoke Tests - Schedule Config", () => {
     }) => {
       await page.goto(`/schedule/${term.label}/config`);
 
-      // Config page is a form with configuration options, not a table
-      // Wait for config form elements to load
-      // Thai: "กำหนดคาบต่อวัน" (Set periods per day)
-      const configLabel = page.locator(
-        "text=/กำหนดคาบต่อวัน|กำหนดระยะเวลาต่อคาบ/",
+      // Config page is now a read-only ConfigSummaryClient: it settles to either
+      // the status badge (config exists) or the empty-state warning after the
+      // SWR spinner — not the old inline form.
+      const statusBadge = page.getByTestId("config-status-badge");
+      const emptyState = page.getByText(
+        "ยังไม่มีการตั้งค่าตารางเรียนสำหรับภาคเรียนนี้",
       );
-      await expect(configLabel.first()).toBeVisible({ timeout: 15000 });
+      await expect(statusBadge.or(emptyState)).toBeVisible({ timeout: 30000 });
     });
 
     test(`/schedule/${term.label}/config has configuration options`, async ({
@@ -49,12 +50,21 @@ test.describe("Semester Smoke Tests - Schedule Config", () => {
     }) => {
       await page.goto(`/schedule/${term.label}/config`);
 
-      // Check for config form labels (not metric cards - those are on dashboard)
-      // Thai: "กำหนดเวลาเริ่มคาบแรก" (Set first period start time), "กำหนดคาบพักเที่ยง" (Set lunch break)
-      const hasConfigOptions = page.locator(
-        "text=/กำหนดเวลาเริ่มคาบแรก|กำหนดคาบพักเที่ยง|กำหนดวันในตารางสอน/",
+      const statusBadge = page.getByTestId("config-status-badge");
+      const emptyState = page.getByText(
+        "ยังไม่มีการตั้งค่าตารางเรียนสำหรับภาคเรียนนี้",
       );
-      await expect(hasConfigOptions.first()).toBeVisible({ timeout: 15000 });
+      await expect(statusBadge.or(emptyState)).toBeVisible({ timeout: 30000 });
+
+      if (await statusBadge.isVisible()) {
+        // Read-only summary lists the saved configuration parameters.
+        await expect(page.getByText("คาบเรียนต่อวัน")).toBeVisible();
+      } else {
+        // Empty state offers the create CTA.
+        await expect(
+          page.getByRole("button", { name: "ตั้งค่าคาบเรียน" }),
+        ).toBeVisible();
+      }
     });
 
     test(`/schedule/${term.label}/config has no console errors`, async ({


### PR DESCRIPTION
The `/schedule/{y}/{s}/config` page is now a read-only `ConfigSummaryClient` —
the old inline-form labels (`กำหนดคาบต่อวัน`, `กำหนดระยะเวลาต่อคาบ`, …) are gone.
`semester-smoke` (renders form / has options) and `critical-smoke` (access page /
verify form loads / navigate between semesters) still asserted those labels.

Rewrite to wait for `config-status-badge` or the empty-state warning (mirroring
the already-rewritten `03-schedule-config` TC-007 tests).

Bucket C `1l9`, **functional** config specs only. The `critical-ui` visual config
screenshots need a baseline regen (bucket A) — out of scope. Validated with
`playwright --list`; CI E2E runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)