### PR TITLE
test(e2e): critical-ui config visual waits target ConfigSummaryClient

### DIFF
--- a/e2e/visual/critical-ui.spec.ts
+++ b/e2e/visual/critical-ui.spec.ts
@@ -62,10 +62,13 @@ test.describe("Critical Admin UI - Visual Tests", () => {
       await page.goto("/schedule/2568/1/config");
       await page.waitForLoadState("networkidle");
 
-      // Wait for config form to load
-      await expect(page.locator("text=/กำหนดคาบต่อวัน/").first()).toBeVisible({
-        timeout: 15000,
-      });
+      // Wait for the read-only ConfigSummaryClient to settle before snapshot
+      // (the old inline-form label "กำหนดคาบต่อวัน" no longer exists).
+      await expect(
+        page
+          .getByTestId("config-status-badge")
+          .or(page.getByText("ยังไม่มีการตั้งค่าตารางเรียนสำหรับภาคเรียนนี้")),
+      ).toBeVisible({ timeout: 30000 });
       await waitForNavbarStable(page);
 
       // Take screenshot with tolerance for minor rendering differences
@@ -88,9 +91,13 @@ test.describe("Critical Admin UI - Visual Tests", () => {
       await page.goto("/schedule/2568/1/config", { timeout: 60000 });
       await page.waitForLoadState("networkidle");
 
-      // Wait for config content to be visible (the page doesn't use a <form> element)
-      // Look for the config section with "กำหนดคาบต่อวัน" text
-      await expect(page.getByText("กำหนดคาบต่อวัน")).toBeVisible({ timeout: 15000 });
+      // Wait for the read-only ConfigSummaryClient to settle (no <form>; the old
+      // "กำหนดคาบต่อวัน" label is gone) before snapshotting.
+      await expect(
+        page
+          .getByTestId("config-status-badge")
+          .or(page.getByText("ยังไม่มีการตั้งค่าตารางเรียนสำหรับภาคเรียนนี้")),
+      ).toBeVisible({ timeout: 30000 });
       await waitForNavbarStable(page);
 
       await expect(page).toHaveScreenshot("config-form.png", {


### PR DESCRIPTION
The two **Semester Configuration** visual tests in `critical-ui.spec.ts` waited
for the removed inline-form label `กำหนดคาบต่อวัน` *before* `toHaveScreenshot`, so
they errored before the snapshot and never compared.

Investigation (via an `update_snapshots` CI run + artifact diff): the committed
`config-page.png` / `config-form.png` Linux baselines are **already** the
ConfigSummaryClient page — regenerating them produced a 0-byte diff. So no
baseline change is needed; the only fix is to wait for `config-status-badge`
(or empty-state) so the test reaches the screenshot and compares against the
already-correct baseline.

Bucket C (critical-ui visual config). CI E2E (compare mode) runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)