### PR TITLE
test(e2e): fix critical-smoke back-button strict-mode collision with stepper

### DIFF
--- a/e2e/smoke/critical-smoke.spec.ts
+++ b/e2e/smoke/critical-smoke.spec.ts
@@ -459,7 +459,10 @@ test.describe("Critical Path Smoke Tests", () => {
       await expect(
         page.getByText("กรุณาเลือกครูผู้สอน"),
       ).toBeVisible({ timeout: 15000 });
-      await expect(page.getByText("ย้อนกลับ")).toBeVisible();
+      // The wizard stepper also renders a "ย้อนกลับ" (previous-step) button on
+      // schedule pages, so scope to the first match to avoid a strict-mode
+      // violation — this smoke check only needs a back affordance present.
+      await expect(page.getByText("ย้อนกลับ").first()).toBeVisible();
       await expect(page).toHaveURL(/\/assign\/teacher_responsibility/);
     });
   });


### PR DESCRIPTION
Regression from #242: the wizard stepper's new `ย้อนกลับ` (previous-step) button
renders on every schedule page, so `getByText("ย้อนกลับ")` at
`critical-smoke.spec.ts:462` (`/assign/teacher_responsibility`) now matches 2
elements → Playwright strict-mode violation.

Scope to `.first()` — the smoke check only needs a back affordance present; the
empty-state text and URL are asserted on the adjacent lines.

CI E2E runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)