### PR TITLE
test(e2e): measure warm load in public-schedule perf test (t29)

### DIFF
--- a/e2e/public-schedule-pages.spec.ts
+++ b/e2e/public-schedule-pages.spec.ts
@@ -663,18 +663,24 @@ test.describe("Public Schedule Pages - Common Features", () => {
     guestPage,
   }) => {
     const page = guestPage;
+    const path = await getPublicTeacherSchedulePath(page);
+
+    // Warm the route first. The first hit pays a one-time cold route compile
+    // (Turbopack/Next dev) that can take ~16s in CI — a build artifact, not a
+    // runtime cost (production is precompiled). Measure the SECOND (warm) load
+    // so the assertion reflects real load performance, not compilation. See t29.
+    await page.goto(path, { timeout: 60000, waitUntil: "domcontentloaded" });
+    await expect(page.locator('main, [role="main"], body').first()).toBeVisible({
+      timeout: 15000,
+    });
+
     const startTime = Date.now();
-
-    await page.goto(await getPublicTeacherSchedulePath(page), { timeout: 60000, waitUntil: "domcontentloaded" });
-    await expect(page.locator('main, [role="main"], body').first()).toBeVisible(
-      {
-        timeout: 15000,
-      },
-    );
-
+    await page.goto(path, { timeout: 60000, waitUntil: "domcontentloaded" });
+    await expect(page.locator('main, [role="main"], body').first()).toBeVisible({
+      timeout: 15000,
+    });
     const loadTime = Date.now() - startTime;
 
-    // Dev mode can be slower due to first-hit compilation.
     const maxMs = process.env.CI ? 5000 : 15000;
     expect(loadTime).toBeLessThan(maxMs);
   });


### PR DESCRIPTION
## Summary
`e2e/public-schedule-pages.spec.ts:662` asserted `loadTime < 5000ms` (CI) but measured the **first** hit of the `(public)` teacher-schedule route, which pays a one-time cold Turbopack/Next route compile (~16s in CI). That's a build artifact, not a runtime cost (production is precompiled) — and it was **deterministically red on `main`**, unrelated to feature PRs.

Fix: warm the route once, then measure the **second (warm)** navigation, so the assertion reflects real load performance instead of compilation.

## Notes
This is the failure that was blocking E2E (parallel) from going green (surfaced while landing #272). Same Turbopack cold-compile family as the deferred `6jo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)